### PR TITLE
Added a function to generate spectra-cn matrix compatible with kat plot

### DIFF
--- a/src/bsg-workspace.cc
+++ b/src/bsg-workspace.cc
@@ -13,7 +13,8 @@ enum WorkspaceFunctions{
     NODE_KCI_DUMP,
     KCI_PROFILE,
     MERGE,
-    ADD_DS
+    ADD_DS,
+    SPECTRA_CN
 };
 struct WorkspaceFunctionMap : public std::map<std::string, WorkspaceFunctions>
 {
@@ -26,6 +27,7 @@ struct WorkspaceFunctionMap : public std::map<std::string, WorkspaceFunctions>
         this->operator[]("kci-profile") = KCI_PROFILE;
         this->operator[]("merge") = MERGE;
         this->operator[]("add") = ADD_DS;
+        this->operator[]("spectra-cn") = SPECTRA_CN;
     };
     ~WorkspaceFunctionMap(){}
 };
@@ -329,6 +331,44 @@ void kci_profile_workspace(int argc,char **argv){
     w.getKCI().compute_kci_profiles(prefix);
 }
 
+void spectra_cn_dump(int argc, char ** argv){
+    std::string filename;
+    std::string prefix;
+
+    try {
+        cxxopts::Options options("bsg-workspace kci-spectra-cn", "BSG workspace kci-spectra-cn");
+
+        options.add_options()
+                ("help", "Print help")
+                ("w,workspace", "workspace filename", cxxopts::value<std::string>(filename))
+                ("p,prefix", "Prefix for the output file", cxxopts::value<std::string>(prefix));
+//                    ("b,whitelist", "Backbone nodeid list", cxxopts::value<std::string>(backbone_whitelist));
+
+        auto newargc=argc-1;
+        auto newargv=&argv[1];
+        auto result=options.parse(newargc,newargv);
+        if (result.count("help")) {
+            std::cout << options.help({""}) << std::endl;
+            exit(0);
+        }
+
+        if (result.count("workspace")==0) {
+            throw cxxopts::OptionException(" please specify kmer spectra file");
+        }
+
+
+    } catch (const cxxopts::OptionException &e) {
+        std::cout << "Error parsing options: " << e.what() << std::endl << std::endl
+                  << "Use option --help to check command line arguments." << std::endl;
+        exit(1);
+    }
+
+    WorkSpace w;
+    w.load_from_disk(filename);
+    w.kci.dump_comp_mx(prefix+"-matrix.mx", 0);
+
+}
+
 void merge_workspace(int argc, char **argv){
     std::vector<int> lr_datastores,pr_datastores,Lr_datastores;
     std::string output="";
@@ -564,6 +604,9 @@ int main(int argc, char * argv[]) {
             break;
         case ADD_DS:
             add_datastores(argc,argv);
+            break;
+        case SPECTRA_CN:
+            spectra_cn_dump(argc,argv);
             break;
         default:
             std::cout << "Invalid option specified." << std::endl;

--- a/src/sglib/processors/KmerCompressionIndex.cc
+++ b/src/sglib/processors/KmerCompressionIndex.cc
@@ -274,6 +274,49 @@ void KmerCompressionIndex::dump_histogram(std::string filename) {
     for (auto i=0;i<1000;++i) kchf<<i<<","<<covuniq[i]<<std::endl;
 }
 
+void KmerCompressionIndex::dump_comp_mx(std::string filename, int kmer_collection){
+    std::ofstream okm(filename);
+    std::cout << "File open..." << std::endl;
+    std::cout << "Graph kmers: "<< this->graph_kmers.size() << std::endl;
+
+    int max_read_cvg = 1001;
+    int max_graph_cvg = 1001;
+    std::vector<std::vector<int>> matrix(max_read_cvg, std::vector<int>(max_read_cvg));
+
+    // Count values and accumulate in the matrix
+    std::cout << "Counting values " << std::endl;
+    for (uint64_t i=0; i<this->graph_kmers.size(); ++i){
+        auto read_cvg = this->read_counts[kmer_collection][i];
+        auto graph_cvg = graph_kmers[i].count;
+        if (read_cvg < max_read_cvg & graph_cvg < max_graph_cvg){
+            matrix[read_cvg][graph_cvg]++;
+        }
+    }
+
+    // Write the headers
+    std::cout << "Dumping matrix " << std::endl;
+    okm << "# Title:K-mer comparison plot generated with BSG" << std::endl;
+    okm << "# XLabel:27-mer frequency for: kmer read collection" << std::endl;
+    okm << "# YLabel:27-mer frequency for: graph kmers" << std::endl;
+    okm << "# ZLabel:# distinct 31-mers" << std::endl;
+    okm << "# Columns:1001" << std::endl;
+    okm << "# Rows:1001" << std::endl;
+    okm << "# MaxVal:NA" << std::endl;
+    okm << "# Transpose:1" << std::endl;
+    okm << "# Kmer value:NA" << std::endl;
+    okm << "# Input 1: Kmer read collection" << std::endl;
+    okm << "# Input 2: Graph" << std::endl;
+    okm << "###" << std::endl;
+
+    // Dump matrix
+    for(auto &row: matrix){
+        for (auto &column: row){
+            okm << column << " ";
+        }
+        okm << std::endl;
+    }
+}
+
 double KmerCompressionIndex::compute_compression_for_node(sgNodeID_t _node, uint16_t max_graph_freq, uint16_t dataset) {
     const int k=31;
     auto n=_node>0 ? _node:-_node;

--- a/src/sglib/processors/KmerCompressionIndex.hpp
+++ b/src/sglib/processors/KmerCompressionIndex.hpp
@@ -159,7 +159,7 @@ public:
      * Accumulates the kmer count from the provided fastq file to the last available read_counts collection
      * @param path to fastq file
      */
-    void add_counts_from_file(std::vector<std::string> filename);
+    void add_counts_from_file(std::vector<std::string> filenames);
 
     /**
      * Accumulates the kmer count from the provided data-store to the last available read_counts collection
@@ -208,6 +208,13 @@ public:
      * @param filename
      */
     void dump_histogram(std::string filename);
+
+    /**
+     * Dumps a kmer comparison matrix between the graph and the selected kmer collection to disk, the matrix is kat compatible
+     * @param filename Output file for the matrix
+     * @param kmer_collection Position of the kmer source in the reads count collection
+     */
+    void dump_comp_mx(std::string filename, int kmer_collection);
 
     /**
      * Computes the kci index for the selected node using the kmers from the node with kmer count in the


### PR DESCRIPTION
Dump a spectra-cn of the 1+ components (no absent distribution)
Using cli:
bsg-workspace spectra-cn -w <workspace> -p <prefix>

Using python:
ws.kci.dump_comp_mx(filename, kmer collection index).

The dumped matrix is compatible with kat plot.
